### PR TITLE
fix: [lab1] fix incorrect pin_count in buffer_pool_test.cpp

### DIFF
--- a/test/unittest/buffer_pool_test.cpp
+++ b/test/unittest/buffer_pool_test.cpp
@@ -24,6 +24,8 @@ void test1()
   const int record_size = 8;
   RecordPageHandler record_page_handle;
   rc = record_page_handle.init_empty_page(*bp, frame->page_num(), record_size);
+  // frame 在allocate_page的时候，是有一个pin的，在init_empty_page时又会增加一个，所以这里手动释放一个
+  frame->unpin();
   ASSERT_EQ(rc, RC::SUCCESS);
 
   char data_buf[record_size] = "1234567";


### PR DESCRIPTION
The issue arises from two instances where a pin operation occurs: one during allocate_page and another within init_empty_page. However, there seems to be only a single unpin operation via record_page_handle.cleanup(). This discrepancy leads to a situation where cannot flush the page because the pin_count_ remains at 1, suggesting that the page is still in use. This could only be a source of frustration for those who checks the pin_count_ during page eviction.

该问题是由发生 pin 操作的两个实例引起的：一个是在 allocate_page 期间，另一个是在 init_empty_page 期间。 然而，似乎只有一个通过 record_page_handle.cleanup() 的unpin操作。 这会导致无法刷新页面的情况，因为 pin_count_ 仍为 1，表明该页面仍在使用中。 这可能只会让那些在页面驱逐期间检查 pin_count_ 的人感到困扰。