### PR TITLE
fix: add force copy ability of class Value; unmatch between IndexScanPhysicalOperator and index_->create_scanner

### DIFF
--- a/src/server/include/query_engine/parser/value.h
+++ b/src/server/include/query_engine/parser/value.h
@@ -39,6 +39,7 @@ public:
   explicit Value(float val);
   explicit Value(bool val);
   explicit Value(const char *s, int len = 0);
+  explicit Value(const char *s, int len, bool force);
   explicit Value(AttrType attrType);
 
   Value(const Value &other) = default;

--- a/src/server/include/query_engine/planner/operator/index_scan_physical_operator.h
+++ b/src/server/include/query_engine/planner/operator/index_scan_physical_operator.h
@@ -24,9 +24,11 @@ public:
  {
     if (left_value != nullptr) {
       left_value_ = *left_value;
+      left_null_ = false;
     }
     if (right_value != nullptr) {
       right_value_ = *right_value;
+      right_null_ = false;
     }
   }
 
@@ -65,5 +67,7 @@ public:
   Value right_value_;
   bool left_inclusive_ = false;
   bool right_inclusive_ = false;
+  bool left_null_ = true;
+  bool right_null_ = true;
   std::vector<std::unique_ptr<Expression>> predicates_;
 };

--- a/src/server/query_engine/parser/value.cpp
+++ b/src/server/query_engine/parser/value.cpp
@@ -43,6 +43,33 @@ Value::Value(const char *s, int len /*= 0*/)
 {
   set_string(s, len);
 }
+
+/**
+ * force mean Force Copy from s
+*/
+Value::Value(const char *s, int len, bool force)
+{
+  if(!force) {
+    set_string(s, len);
+  } else {
+    //为规避0带来的截断问题，我们先将其均置为1，并记录其位置以将其复原
+    char *data_tmp = new char[len];
+    std::vector<int> places_of_zeros;
+    for(int i = 0; i < len; i++) {
+      data_tmp[i] = s[i];
+      if(s[i] == 0) {
+        places_of_zeros.push_back(i);
+        data_tmp[i] = 1;
+      }
+    }
+    set_string(data_tmp, len);
+    //复原
+    for(int i = 0; i < places_of_zeros.size(); i++) {
+      str_value_[places_of_zeros[i]] = 0;
+    }
+    delete[] data_tmp;
+  }
+}
 Value::Value(AttrType attrType)
 {
   switch (attrType) {

--- a/src/server/query_engine/planner/operator/index_scan_physical_operator.cpp
+++ b/src/server/query_engine/planner/operator/index_scan_physical_operator.cpp
@@ -12,11 +12,13 @@ RC IndexScanPhysicalOperator::open(Trx *trx)
     return RC::INTERNAL;
   }
 
-  IndexScanner *index_scanner = index_->create_scanner(left_value_.data(),
-                                                       left_value_.length(),
+  const char *left_key = left_null_ ? nullptr : left_value_.data();
+  const char *right_key = right_null_ ? nullptr : right_value_.data();
+  IndexScanner *index_scanner = index_->create_scanner(left_key, 
+                                                       left_value_.length(), 
                                                        left_inclusive_,
-                                                       right_value_.data(),
-                                                       right_value_.length(),
+                                                       right_key, 
+                                                       right_value_.length(), 
                                                        right_inclusive_);
   if(index_scanner == nullptr)
   {

--- a/src/server/storage_engine/recorder/table_meta.cpp
+++ b/src/server/storage_engine/recorder/table_meta.cpp
@@ -224,7 +224,10 @@ const IndexMeta *TableMeta::index(const char *name) const
 const IndexMeta *TableMeta::find_index_by_field(const char *field) const
 {
   for (const IndexMeta &index : indexes_) {
-    if (0 == strcmp(index.field(0), field)) {
+    // if (0 == strcmp(index.field(0), field)) {
+    //   return &index;
+    // }
+    if (0 == strcmp(index.multi_fields(), field)) {
       return &index;
     }
   }


### PR DESCRIPTION
# 问题背景：
1. 我现在想给单列做不等式的索引优化。
2. 原来的api有这个能力（设定左右边界），但是实现有问题
3. 具体体现如下
	1. 假设我现在 `select * from index_lab where id > 99997; `
	2. 那么我对应的有 
```c++
IndexScanPhysicalOperator *index_scan_oper = new IndexScanPhysicalOperator(table, index, table_get_oper.readonly(), 
       &value, false /* left_inclusive */, 
       nullptr, false /* right_inclusive */ );
```

> 之所以是nullptr是因为BplusTreeScanner::open中就是这样考虑的（右边无边界） 

问题在于源码中没有能够将nullptr传递下去而是默认传递其内部的right_value_.data()(在上述例子的情况下)，导致BplusTreeScanner::open失败

# 修改思路：
添加`left_null_`和`right_null_`的标识量，修改index_->create_scanner的传参逻辑即可，不影响原来的逻辑。

---

# Background:
1. I am currently looking to optimize inequality for a single-column index.
2. The original API has the capability to set left and right boundaries, but there is a problem with the implementation.
3. The specific issue is as follows:
	1. Assume I am now querying `select * from index_lab where id > 99997;`
	2. The corresponding C++ code snippet is:
```c++
IndexScanPhysicalOperator *index_scan_oper = new IndexScanPhysicalOperator(table, index, table_get_oper.readonly(), 
       &value, false /* left_inclusive */, 
       nullptr, false /* right_inclusive */ );
```

> The reason why nullptr is used is that this is how BplusTreeScanner::open is set (right boundary is unbounded).

The problem is that the source code does not allow nullptr to be passed down but instead defaults to passing its internal right_value_.data() (in the aforementioned example), which causes BplusTreeScanner::open to fail.

# Proposed Modification:
Add flags for `left_null_` and `right_null_`, and modify the parameter logic in index_->create_scanner accordingly. This should not affect the original logic.