### PR TITLE
fix: wrong index in cell_at() of JoinTuple and redundant species when calling open() repeatedly

### DIFF
--- a/src/server/include/query_engine/structor/tuple/join_tuple.h
+++ b/src/server/include/query_engine/structor/tuple/join_tuple.h
@@ -44,7 +44,7 @@ public:
   RC cell_at(int index, Value &value) const override
   {
     const int left_cell_num = left_->cell_num();
-    if (index > 0 && index < left_cell_num) {
+    if (index >= 0 && index < left_cell_num) {
       return left_->cell_at(index, value);
     }
 

--- a/src/server/include/query_engine/structor/tuple/row_tuple.h
+++ b/src/server/include/query_engine/structor/tuple/row_tuple.h
@@ -36,13 +36,19 @@ public:
    this->bitmap_.init(record->data() + null_filed_meta->offset(), null_filed_meta->len());
  }
 
+
  void set_schema(const Table *table, const std::string &table_alias, const std::vector<FieldMeta> *fields)
  {
    table_ = table;
    table_alias_ = table_alias;
-   species_.clear();   /// 在TableScanPhysicalOperator::open()会调用set_schema。
-                       //如果不加clear()，当同一个operator多次open()时，sepcies_就会积累多套重复的fields。
    this->species_.reserve(fields->size());
+   if(!species_.empty()){
+    for(auto& field_expr : species_){
+      delete field_expr;  //clear()前先释放目前的fields
+    }
+    species_.clear();/// 在TableScanPhysicalOperator::open()会调用set_schema。
+                     //如果不加clear()，当同一个operator多次open()时，sepcies_就会积累多套重复的fields。
+   }
    for (const FieldMeta &field : *fields) {
      species_.push_back(new FieldExpr(table, &field));
      species_[species_.size() - 1]->set_field_table_alias(table_alias);

--- a/src/server/include/query_engine/structor/tuple/row_tuple.h
+++ b/src/server/include/query_engine/structor/tuple/row_tuple.h
@@ -40,7 +40,8 @@ public:
  {
    table_ = table;
    table_alias_ = table_alias;
-   species_.clear();
+   species_.clear();   /// 在TableScanPhysicalOperator::open()会调用set_schema。
+                       //如果不加clear()，当同一个operator多次open()时，sepcies_就会积累多套重复的fields。
    this->species_.reserve(fields->size());
    for (const FieldMeta &field : *fields) {
      species_.push_back(new FieldExpr(table, &field));

--- a/src/server/include/query_engine/structor/tuple/row_tuple.h
+++ b/src/server/include/query_engine/structor/tuple/row_tuple.h
@@ -40,6 +40,7 @@ public:
  {
    table_ = table;
    table_alias_ = table_alias;
+   species_.clear();
    this->species_.reserve(fields->size());
    for (const FieldMeta &field : *fields) {
      species_.push_back(new FieldExpr(table, &field));


### PR DESCRIPTION
bug 1:  join tuple cannot be visited by cell_at() at position 0
bug 2: row tuple's schema will be double or triple initialized when trying to reopen table scanner