### PR TITLE
fix(mvcc): fix commit xid may be accidentally reused

### DIFF
--- a/src/server/include/storage_engine/transaction/mvcc_trx.h
+++ b/src/server/include/storage_engine/transaction/mvcc_trx.h
@@ -23,6 +23,9 @@ public:
   int32_t next_trx_id();
   int32_t max_trx_id() const;
 
+  // 在 recover 场景下使用，确保当前事务 id 不小于 trx_id
+  void update_trx_id(int32_t trx_id);
+
 private:
   std::vector<FieldMeta> fields_; // 存储事务数据需要用到的字段元数据，所有表结构都需要带
   std::atomic<int32_t> current_trx_id_{0};


### PR DESCRIPTION
**问题：** 在事务恢复阶段，`MTR_BEGIN` 日志对应的 trx id 会在 `MvccTrxManager` 类的 `create_trx(int32_t trx_id)` 方法中更新 `current_trx_id` 以避免重复使用，符合预期。但是 `MTR_COMMIT` 日志所使用的 commit xid 没有更新，可能会被重用而导致错误的结果。

**解决方案：** 增加 `update_trx_id` 方法用于确保 `current_trx_id` 不小于给定的参数。在 recover 阶段，`MvccTrx` 提交时应当调用该方法更新 `current_trx_id`。