### PR TITLE
fix issue #25, 在mvcc场景下，多事务执行删除会出错

### DIFF
--- a/src/server/include/storage_engine/recorder/record_manager.h
+++ b/src/server/include/storage_engine/recorder/record_manager.h
@@ -3,6 +3,7 @@
 #include "include/storage_engine/buffer/buffer_pool.h"
 #include "include/storage_engine/recorder/record.h"
 #include "include/storage_engine/recorder/condition_filter.h"
+#include "include/query_engine/structor/expression/expression.h"
 #include "common/lang/bitmap.h"
 
 class ConditionFilter;
@@ -323,6 +324,7 @@ public:
    * @param condition_filter 做一些初步过滤操作
    */
   RC open_scan(Table *table, FileBufferPool &buffer_pool, Trx *trx, bool readonly, ConditionFilter *condition_filter);
+  RC open_scan(Table *table, FileBufferPool &buffer_pool, Trx *trx, bool readonly, std::vector<std::unique_ptr<Expression>> predicate_exprs);
 
   /**
    * @brief 关闭一个文件扫描，释放相应的资源
@@ -367,4 +369,6 @@ private:
   RecordPageHandler  record_page_handler_;         // 处理文件某页面的记录
   RecordPageIterator record_page_iterator_;        // 遍历某个页面上的所有record
   Record             next_record_;                 // 获取的记录放在这里缓存起来
+  std::vector<std::unique_ptr<Expression>> predicates_; // 过滤的谓词
+
 };

--- a/src/server/include/storage_engine/recorder/table.h
+++ b/src/server/include/storage_engine/recorder/table.h
@@ -90,6 +90,8 @@ public:
 
   RC get_record_scanner(RecordFileScanner &scanner, Trx *trx, bool readonly);
 
+  RC get_record_scanner(RecordFileScanner &scanner, Trx *trx, bool readonly, std::vector<std::unique_ptr<Expression>> predicate_exprs);
+
   RecordFileHandler *record_handler() const
   {
     return record_handler_;

--- a/src/server/query_engine/planner/operator/table_scan_physical_operator.cpp
+++ b/src/server/query_engine/planner/operator/table_scan_physical_operator.cpp
@@ -5,7 +5,8 @@ using namespace std;
 
 RC TableScanPhysicalOperator::open(Trx *trx)
 {
-  RC rc = table_->get_record_scanner(record_scanner_, trx, readonly_);
+  // 将predicates_传下去，让record_scanner_做过滤
+  RC rc = table_->get_record_scanner(record_scanner_, trx, readonly_,std::move(predicates_));
   if (rc == RC::SUCCESS) {
     tuple_.set_schema(table_, table_alias_, table_->table_meta().field_metas());
   }

--- a/src/server/storage_engine/recorder/table.cpp
+++ b/src/server/storage_engine/recorder/table.cpp
@@ -2,6 +2,8 @@
 #include "include/storage_engine/recorder/record_manager.h"
 #include "include/storage_engine/schema/schema_util.h"
 #include "include/storage_engine/index/bplus_tree_index.h"
+#include "include/storage_engine/transaction/mvcc_trx.h"
+#include "include/storage_engine/transaction/trx.h"
 #include <random>
 
 
@@ -486,6 +488,18 @@ RC Table::get_record_scanner(RecordFileScanner &scanner, Trx *trx, bool readonly
   RC rc = scanner.open_scan(this, *data_buffer_pool_, trx, readonly, nullptr);
   if (rc != RC::SUCCESS) {
     LOG_ERROR("failed to open scanner. rc=%s", strrc(rc));
+  }
+  return rc;
+}
+
+RC Table::get_record_scanner(
+    RecordFileScanner &scanner, Trx *trx, bool readonly,
+    std::vector<std::unique_ptr<Expression>> predicate_exprs) {
+  
+  RC rc = scanner.open_scan(this, *data_buffer_pool_, trx, readonly,
+                            std::move(predicate_exprs));
+  if (rc != RC::SUCCESS) {
+    LOG_WARN("failed to open scanner. rc=%s", strrc(rc));
   }
   return rc;
 }


### PR DESCRIPTION
修复了问题#25, 即lab5文档中的sql测试完成后，能删除id=0以外的数据了(如图1)，删除id=0或delete from t_redo(删除全部数据，如图2)依然会触发写写冲突（因为transaction4的事务没有提交导致的）

![image](https://github.com/THSS-DB/TDB/assets/107929684/d622d7b5-405b-415f-b3d7-e10bfba6d9b3)
![53a24b2087b2e4745b5a300192aff96](https://github.com/THSS-DB/TDB/assets/107929684/484cfe6c-4154-4e00-ac86-691d46d95b3b)
