### PR TITLE
minor fixes

### DIFF
--- a/src/server/include/query_engine/planner/operator/index_scan_physical_operator.h
+++ b/src/server/include/query_engine/planner/operator/index_scan_physical_operator.h
@@ -51,7 +51,7 @@ public:
 
   std::string param() const override;
 
-  void set_predicates(std::vector<std::unique_ptr<Expression>> &predicates) {
+  void set_predicates(std::vector<std::unique_ptr<Expression>> &&predicates) {
     predicates_ = std::move(predicates);
   }
 

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -18,7 +18,7 @@ static Server *g_server = nullptr;
 
 void usage()
 {
-  std::cout << "Useage " << std::endl;
+  std::cout << "Usage " << std::endl;
   std::cout << "-p: server port. if not specified, the item in the config file will be used" << std::endl;
   std::cout << "-f: path of config file." << std::endl;
   std::cout << "-s: use unix socket and the argument is socket address" << std::endl;

--- a/src/server/query_engine/analyzer/statement/select_stmt.cpp
+++ b/src/server/query_engine/analyzer/statement/select_stmt.cpp
@@ -10,6 +10,8 @@
 #include "include/storage_engine/schema/database.h"
 #include "include/storage_engine/recorder/table.h"
 
+#include <algorithm>
+
 SelectStmt::~SelectStmt()
 {
   // 这些都是 create 中创建的对象，独占所有权，需要释放

--- a/src/server/query_engine/planner/operator/order_physical_operator.cpp
+++ b/src/server/query_engine/planner/operator/order_physical_operator.cpp
@@ -3,6 +3,8 @@
 #include "include/storage_engine/recorder/record.h"
 #include "include/query_engine/analyzer/statement/filter_stmt.h"
 #include "include/storage_engine/recorder/field.h"
+#include <algorithm>
+
 OrderPhysicalOperator::OrderPhysicalOperator(std::vector<OrderByUnit *> order_units) : order_units_(std::move(order_units))
 {}
 


### PR DESCRIPTION
具体改动如下：
1. 修复main.cpp中的typo。
2. 本地编译时select_stmt.cpp和order_physical_operator.cpp两个文件突然报错缺少`<algorithm>`头文件，使用g++ -E展开所有头文件后发现确实没有引入。虽然不清楚为什么以前编译成功过，但是加上应该会更加保险。
3. 将`IndexScanPhysicalOperator`中`set_predicates`的参数改为右值引用，更加符合函数内的移动语义，且与`TableGetLogicalNode`以及`TableScanPhysicalOperator`的行为保持一致。